### PR TITLE
nuitka 2.7.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/scons-feedstock/pr4/2985e07

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/scons-feedstock/pr3/556c7a7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scons-feedstock/pr3/556c7a7
+  - https://staging.continuum.io/prefect/fs/scons-feedstock/pr4/2985e07

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:                    # [win]
+  - vs2022                     # [win]
+cxx_compiler:                  # [win]
+  - vs2022                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Nuitka" %}
-{% set version = "1.5.8" %}
+{% set version = "2.7.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 729806f45d8a7cf45a843a92752f392e6a821653ba72d46505b6c154be0d3853
+  sha256: 8ad661b57dec9753ca93c59232bf40bc3288d79da46492cc574cfca640d81d13
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,14 @@ requirements:
   run:
     - python
     - libpython-static  # [not win]
-    - ordered-set >=4.1.0
-    - zstandard >=0.15
+    - ordered-set >=4.1.0  # [py>=37]
+    - orderedset >=2.0.3  # [py<37]
+    - zstandard >=0.15  # [py>=35]
+    - jinja2 >=2.10.2
+    # Optional but recommended
+    - appdirs
+    - tqdm  # [py==27 or py>=34]
+    - pyyaml  # [py==27 or py>=36]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Nuitka" %}
-{% set version = "2.7.6" %}
+{% set version = "2.7.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8ad661b57dec9753ca93c59232bf40bc3288d79da46492cc574cfca640d81d13
+  sha256: ee28e5699005904e83250ad1b3192cf2c5b46bebbf4ae12f6fc5efa4a0368c16
   patches:
     - patches/0001-Remove-vendored-zlib-and-zstd-from-setup.py.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 8ad661b57dec9753ca93c59232bf40bc3288d79da46492cc574cfca640d81d13
 
 build:
+  skip: True  # [unix]
   number: 0
   script_env:
     - NUITKA_NO_INLINE_COPY=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - scons
   run:
     - python
     - libpython-static  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 8ad661b57dec9753ca93c59232bf40bc3288d79da46492cc574cfca640d81d13
 
 build:
-  skip: True  # [unix]
   number: 0
   script_env:
     - NUITKA_NO_INLINE_COPY=1
+    - NUITKA_ASSUME_YES_FOR_DOWNLOADS=1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - nuitka = nuitka.__main__:main
@@ -56,15 +56,17 @@ test:
     - nuitka.utils
   requires:
     - pip
-    - {{ compiler('c') }}  # [linux]
+    - {{ compiler('c') }}
   commands:
     - pip check
     - nuitka --help
     - nuitka-run --help
     - python -m nuitka --version
-    - touch Empty.py
+    - touch Empty.py  # [unix]
+    - python -c "open('Empty.py', 'w').close()"  # [win]
     # Disable ccache in the test compilation because of the frozen prompt
-    - nuitka --show-scons --run --verbose --disable-ccache Empty.py
+    - nuitka --show-scons --run --verbose --disable-ccache --mingw64 --assume-yes-for-downloads Empty.py  # [win]
+    - nuitka --show-scons --run --verbose --disable-ccache Empty.py  # [unix]
 
 about:
   home: https://nuitka.net

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - appdirs
     - tqdm  # [py==27 or py>=34]
     - pyyaml  # [py==27 or py>=36]
+    # https://github.com/Nuitka/Nuitka/issues/3500
     - scons 4.1.0.post1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - scons
+    - scons 4.1.0.post1
   run:
     - python
     - libpython-static  # [not win]
@@ -37,7 +37,7 @@ requirements:
     - appdirs
     - tqdm  # [py==27 or py>=34]
     - pyyaml  # [py==27 or py>=36]
-    - scons
+    - scons 4.1.0.post1
 
 test:
   imports:
@@ -57,7 +57,7 @@ test:
   requires:
     - pip
     - {{ compiler('c') }}
-    - scons  # [win]
+    - scons 4.1.0.post1  # [win]
   commands:
     - pip check
     - nuitka --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ test:
     - touch Empty.py  # [unix]
     - python -c "open('Empty.py', 'w').close()"  # [win]
     # Disable ccache in the test compilation because of the frozen prompt
-    - nuitka --show-scons --run --verbose --disable-ccache --assume-yes-for-downloads Empty.py  # [win]
+    - nuitka --show-scons --run --verbose --disable-ccache --msvc=14.3 --assume-yes-for-downloads Empty.py  # [win]
     - nuitka --show-scons --run --verbose --disable-ccache Empty.py  # [unix]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ test:
   requires:
     - pip
     - {{ compiler('c') }}
+    - scons  # [win]
   commands:
     - pip check
     - nuitka --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,17 @@ build:
     - nuitka-run = nuitka.__main__:main
 
 requirements:
+  build:
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - python
     - pip
     - setuptools
     - wheel
     - scons 4.1.0.post1
+    - zlib
+    - zstd
   run:
     - python
     - libpython-static  # [not win]
@@ -50,8 +55,8 @@ requirements:
     #- pkg_resources
     #- bin  # ??
     - scons 4.1.0.post1
-    - zlib {{ zlib }}
-    - zstd {{ zstd }}
+    - zlib
+    - zstd
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ test:
     - touch Empty.py  # [unix]
     - python -c "open('Empty.py', 'w').close()"  # [win]
     # Disable ccache in the test compilation because of the frozen prompt
-    - nuitka --show-scons --run --verbose --disable-ccache --mingw64 --assume-yes-for-downloads Empty.py  # [win]
+    - nuitka --show-scons --run --verbose --disable-ccache --assume-yes-for-downloads Empty.py  # [win]
     - nuitka --show-scons --run --verbose --disable-ccache Empty.py  # [unix]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ requirements:
     - setuptools
     - wheel
     - scons 4.1.0.post1
-    - zlib
-    - zstd
+    - zlib {{ zlib }}
+    - zstd {{ zstd }}
   run:
     - python
     - libpython-static  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8ad661b57dec9753ca93c59232bf40bc3288d79da46492cc574cfca640d81d13
+  patches:
+    - patches/0001-Remove-vendored-zlib-and-zstd-from-setup.py.patch
 
 build:
   number: 0
@@ -48,6 +50,8 @@ requirements:
     #- pkg_resources
     #- bin  # ??
     - scons 4.1.0.post1
+    - zlib {{ zlib }}
+    - zstd {{ zstd }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ requirements:
     - markupsafe
     - tqdm
     - atomicwrites # [win]
-    - clcache # [win]
     - colorama # [win]
     - pefile # [win]
     - pyyaml  # [py>=36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
   number: 0
   script_env:
     - NUITKA_NO_INLINE_COPY=1
-    - NUITKA_ASSUME_YES_FOR_DOWNLOADS=1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - nuitka = nuitka.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  script_env:
+    - NUITKA_NO_INLINE_COPY=1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - nuitka = nuitka.__main__:main
@@ -33,6 +35,7 @@ requirements:
     - appdirs
     - tqdm  # [py==27 or py>=34]
     - pyyaml  # [py==27 or py>=36]
+    - scons
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,11 +33,20 @@ requirements:
     - orderedset >=2.0.3  # [py<37]
     - zstandard >=0.15  # [py>=35]
     - jinja2 >=2.10.2
-    # Optional but recommended
+     # Was addInlineCopy()
     - appdirs
-    - tqdm  # [py==27 or py>=34]
-    - pyyaml  # [py==27 or py>=36]
-    # https://github.com/Nuitka/Nuitka/issues/3500
+    - glob2
+    - markupsafe
+    - tqdm
+    - atomicwrites # [win]
+    - clcache # [win]
+    - colorama # [win]
+    - pefile # [win]
+    - pyyaml  # [py>=36]
+    - jinja2  # [py>=36]
+    # XXX pkg_resources is bundled with setuptools now (or something)
+    #- pkg_resources
+    #- bin  # ??
     - scons 4.1.0.post1
 
 test:

--- a/recipe/patches/0001-Remove-vendored-zlib-and-zstd-from-setup.py.patch
+++ b/recipe/patches/0001-Remove-vendored-zlib-and-zstd-from-setup.py.patch
@@ -1,0 +1,46 @@
+From f43a6f4acc6af023900e9caeb549553e52541bde Mon Sep 17 00:00:00 2001
+From: Steven <scrass@anaconda.com>
+Date: Fri, 11 Jul 2025 08:56:12 -0600
+Subject: [PATCH] Remove vendored zlib and zstd from setup.py
+
+This patch removes the vendored copies of zlib and zstd libraries from
+the Nuitka package data, allowing the package to rely on system-provided
+versions of these libraries instead.
+
+The following vendored library references have been removed:
+- inline_copy/zstd/LICENSE.txt
+- inline_copy/zstd/*.h
+- inline_copy/zstd/*/*.h
+- inline_copy/zstd/*/*.c
+- inline_copy/zlib/LICENSE
+- inline_copy/zlib/*.h
+- inline_copy/zlib/*.c
+
+This change reduces the package size and ensures compatibility with
+system-provided versions of these libraries.
+---
+ setup.py | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 1c4439648..6c25237e6 100644
+--- a/setup.py
++++ b/setup.py
+@@ -155,13 +155,7 @@ package_data = {
+         "static_src/*.cpp",
+         "static_src/*/*.c",
+         "static_src/*/*.h",
+-        "inline_copy/zstd/LICENSE.txt",
+-        "inline_copy/zstd/*.h",
+-        "inline_copy/zstd/*/*.h",
+-        "inline_copy/zstd/*/*.c",
+-        "inline_copy/zlib/LICENSE",
+-        "inline_copy/zlib/*.h",
+-        "inline_copy/zlib/*.c",
++
+         "inline_copy/python_hacl/LICENSE.txt",
+         "inline_copy/python_hacl/hacl_312/*.h",
+         "inline_copy/python_hacl/hacl_312/*.c",
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7438](https://anaconda.atlassian.net/browse/PKG-7438)
- [Upstream repository](https://github.com/Nuitka/Nuitka/tree/hotfix/2.7.6)

### Explanation of changes:

- Set new version and sha256
- Build using `NUITKA_NO_INLINE_COPY=1`
- Update dependencies
- Add `scons` with specific pinning (see https://github.com/Nuitka/Nuitka/issues/3500)
- Unvendor `zlib` and `zstd`

[PKG-7438]: https://anaconda.atlassian.net/browse/PKG-7438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ